### PR TITLE
Allow passing mutliple QROptions

### DIFF
--- a/src/GenerateQrCode.php
+++ b/src/GenerateQrCode.php
@@ -67,15 +67,13 @@ class GenerateQrCode
     /**
      * Render the QR code as base64 data image.
      *
+     * @param  array  $options  The list of options for QROption (https://github.com/chillerlan/php-qrcode)
+     *
      * @return string
      */
-    public function render($scale = 5): string
+    public function render(array $options = []): string
     {
-        $options = new QROptions(
-            [
-              'scale' => $scale,
-            ]
-          );
+        $options = new QROptions($options);
         return (new QRCode($options))->render($this->toBase64());
     }
 }


### PR DESCRIPTION
I have seen #7 which is great 👍🏼 
However, it would be more efficient passing all the options according to the user needs (since QROptions has multiple options).
Also, this allows the user to utilize any added features to the `chillerlan\QRCode` package in the future 💡 

An example for scale would be:
```php
$displayQRCodeAsBase64 = GenerateQrCode::fromArray([
.....
])->render(['scale' => 3]);
```

PS. Thanks for this simple yet elegant solution .. you saved a lot of time for many developers including myself ❤️