### PR TITLE
Enable file save in render method

### DIFF
--- a/src/GenerateQrCode.php
+++ b/src/GenerateQrCode.php
@@ -65,15 +65,28 @@ class GenerateQrCode
     }
 
     /**
-     * Render the QR code as base64 data image.
+     * Render the QR code as base64 encoded image string or/and save file.
      *
-     * @param  array  $options  The list of options for QROption (https://github.com/chillerlan/php-qrcode)
+     * @param  mixed  $args  Mixed of first two arguments: QROption settings list [optional] or/and file to be saved [optional] (https://github.com/chillerlan/php-qrcode)
      *
      * @return string
      */
-    public function render(array $options = []): string
+    public function render(...$args): string
     {
-        $options = new QROptions($options);
-        return (new QRCode($options))->render($this->toBase64());
+        foreach ($args as $key => $arg) {
+            if ($key > 1) {
+                break;
+            }
+
+            if (is_array($arg)) {
+                $options = $arg;
+            }
+
+            if (is_string($arg)) {
+                $file = $arg;
+            };
+        }
+        $options = new QROptions($options ?? []);
+        return (new QRCode($options))->render($this->toBase64(), $file ?? null);
     }
 }

--- a/src/GenerateQrCode.php
+++ b/src/GenerateQrCode.php
@@ -65,28 +65,16 @@ class GenerateQrCode
     }
 
     /**
-     * Render the QR code as base64 encoded image string or/and save file.
+     * Render the QR code as base64 data image.
      *
-     * @param  mixed  $args  Mixed of first two arguments: QROption settings list [optional] or/and file to be saved [optional] (https://github.com/chillerlan/php-qrcode)
+     * @param  array  $options  The list of options for QROption (https://github.com/chillerlan/php-qrcode)
+     * @param  string|null  $file  File string represent file path,name and extension
      *
      * @return string
      */
-    public function render(...$args): string
+    public function render(array $options = [], string $file = null): string
     {
-        foreach ($args as $key => $arg) {
-            if ($key > 1) {
-                break;
-            }
-
-            if (is_array($arg)) {
-                $options = $arg;
-            }
-
-            if (is_string($arg)) {
-                $file = $arg;
-            }
-        }
-        $options = new QROptions($options ?? []);
-        return (new QRCode($options))->render($this->toBase64(), $file ?? null);
+        $options = new QROptions($options);
+        return (new QRCode($options))->render($this->toBase64(), $file);
     }
 }

--- a/src/GenerateQrCode.php
+++ b/src/GenerateQrCode.php
@@ -84,7 +84,7 @@ class GenerateQrCode
 
             if (is_string($arg)) {
                 $file = $arg;
-            };
+            }
         }
         $options = new QROptions($options ?? []);
         return (new QRCode($options))->render($this->toBase64(), $file ?? null);


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

*  Adding file save feature

What is the current behaviour? (You can also link to an open issue here)

* the current behaviour it recieve array of options without argument for saving file which provided by chillerlan/php-qrcode

What is the new behaviour? (You can also link to the ticket here)

* I edit render method of GenerateQrCode class, to accept mixed arguments, I only process on two arguments, if each of one arguments is string I consider it file path, otherwise I consider it array  argument for QROptions class.
* arrangement of two arguments ignored, and more than 2 arguments also ignored.
* I use this way to make render call clean and to avoid breaking of previous behaviour.

Does this PR introduce a breaking change?

* No