### PR TITLE
fix(FIX-2025): Make the signing-time in UTC

### DIFF
--- a/src/Helpers/UblExtension.php
+++ b/src/Helpers/UblExtension.php
@@ -33,7 +33,7 @@ class UblExtension
      */
     public function populateUblSignature(): string
     {
-        $signingTime = date('Y-m-d') . 'T' . date('H:m:s');
+        $signingTime = gmdate("Y-m-d") . 'T' . gmdate("H:i:s") . 'Z';
 
         $signedProprietiesXml = $this->buildSignedProperties($signingTime);
 

--- a/src/Helpers/UblExtension.php
+++ b/src/Helpers/UblExtension.php
@@ -33,7 +33,7 @@ class UblExtension
      */
     public function populateUblSignature(): string
     {
-        $signingTime = gmdate("Y-m-d") . 'T' . gmdate("H:i:s") . 'Z';
+        $signingTime = gmdate('Y-m-d') . 'T' . gmdate('H:i:s') . 'Z';
 
         $signedProprietiesXml = $this->buildSignedProperties($signingTime);
 


### PR DESCRIPTION
Although the application timezone may vary based on configuration or user preferences, the invoice signing process must always record the signing time in UTC to ensure consistency, accuracy, and legal validity across different regions.