### PR TITLE
fix: typo with exception message

### DIFF
--- a/src/Models/CSRRequest.php
+++ b/src/Models/CSRRequest.php
@@ -125,7 +125,7 @@ class CSRRequest
     public function setUID(string $UID): self
     {
         if (strlen($UID) !== 15 || substr($UID, 0, 1) != '3' || substr($UID, -1, 1) != '3') {
-            throw new CSRValidationException('The Organization Identifier must be 15 digits, starting andending with 3 ', 422);
+            throw new CSRValidationException('The Organization Identifier must be 15 digits, starting and ending with 3 ', 422);
         }
 
         $this->UID = $UID;
@@ -252,3 +252,4 @@ class CSRRequest
         return $this->countryName;
     }
 }
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a typo in the `CSRRequest::setUID()` exception message where `"starting andending with 3"` was missing a space, correcting it to `"starting and ending with 3"`. Also adds a trailing newline at end of file. No logic or behavior changes.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it only fixes a typo in an error message string with zero logic changes.
- The change is a single-character space insertion in a string literal. No code logic, control flow, or behavior is affected. The risk of regression is effectively zero.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/Models/CSRRequest.php | Fixes a typo in an exception message: adds missing space between "and" and "ending". Also adds a trailing newline at end of file. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setUID called] --> B{Validate UID}
    B -->|Invalid| C[Throw CSRValidationException with fixed typo]
    B -->|Valid| D[Set UID property]
```
</details>


<sub>Last reviewed commit: dea7cf1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->