### PR TITLE
chore: `chillerlan/php-qrcode`: from v4 to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-dom": "*",
         "robrichards/xmlseclibs": "^3.1",
         "josemmo/uxml": "^0.1.4",
-        "chillerlan/php-qrcode": "^4.3",
+        "chillerlan/php-qrcode": "^5.0",
         "phpseclib/phpseclib": "~3.0"
     },
     "require-dev": {

--- a/src/GenerateQrCode.php
+++ b/src/GenerateQrCode.php
@@ -5,6 +5,7 @@ namespace Salla\ZATCA;
 use chillerlan\QRCode\QRCode;
 use InvalidArgumentException;
 use chillerlan\QRCode\QROptions;
+use chillerlan\QRCode\Output\QROutputInterface;
 
 class GenerateQrCode
 {
@@ -72,9 +73,18 @@ class GenerateQrCode
      *
      * @return string
      */
-    public function render(array $options = [], string $file = null): string
+    public function render(array $options = [], ?string $file = null): string
     {
+        if (!isset($options['outputType']) && !isset($options['outputInterface'])) {
+            $options['outputType'] = QROutputInterface::GDIMAGE_PNG;
+        }
+        
+        if (!isset($options['imageTransparent'])) {
+            $options['imageTransparent'] = true;
+        }
+        
         $options = new QROptions($options);
+
         return (new QRCode($options))->render($this->toBase64(), $file);
     }
 }


### PR DESCRIPTION
This PR updates [https://github.com/chillerlan/php-qrcode/](https://github.com/chillerlan/php-qrcode/) to version 5.

It sets the default QR rendering options to the following:
1. Transparent background  
2. Uses GD  
3. Outputs in PNG format  

These were the defaults in version 4, and they are now set explicitly to minimize the impact of this update.

Of course, users can still pass their own options to the render function: `Salla\ZATCA\GenerateQrCode::render`. (Maybe this worth noting in the README?)

____

Also, it might be better and safer to bump the major version of this package to reflect the dependency upgrade and potential changes introduced by updating chillerlan/php-qrcode to v5.
____

Related PRs: #63 , #46

____

You might want to take a look here:

1. The "options" changes: https://github.com/chillerlan/php-qrcode/issues/223 

2. The GD+PNG+Transparency defaults: [v5.0.0 release](https://github.com/chillerlan/php-qrcode/discussions/227)  

> [breaking] The default output has been changed from PNG (GdImage) to SVG. No image processing extension (ext-gd or ext-imagick) required anymore!

> [breaking] The default value of QROptions::$imageTransparent has been set to false due to various issues and misconceptions with transparency in GD and ImageMagick, therefore: use at your own risk.


_____

_____


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Upgrades `chillerlan/php-qrcode` from v4 to v5 and sets explicit rendering defaults (GD+PNG+transparency) to preserve v4 behavior and minimize breaking changes for existing users.

- Updated dependency constraint from ^4.3 to ^5.0
- Added explicit `outputType` default (`QROutputInterface::GDIMAGE_PNG`) to maintain GD+PNG output (v5 defaults to SVG)
- Added explicit `imageTransparent` default (true) to maintain transparent backgrounds (v5 defaults to false)
- Users can still override defaults by passing custom options to `render()`

**Key considerations:**
- The PR author correctly notes this may warrant a major version bump given the underlying dependency upgrade
- No tests added to verify the new default behavior or that custom options properly override defaults
- The existing test (`shouldGenerateAQrCodeDisplayAsImageData`) verifies PNG output format but doesn't test transparency or custom options scenarios

<details open><summary><h3>Confidence Score: 3/5</h3></summary>


- This PR is relatively safe but requires additional test coverage before merging
- Score reflects missing test coverage for the new default behavior and potential option override scenarios. While the implementation correctly preserves v4 defaults to minimize breaking changes, the lack of tests for transparency settings and custom options validation creates uncertainty. The existing test only validates PNG output format but doesn't verify transparency or that user-provided options properly override the new defaults. Custom instruction 66cc2964 requires 95% test coverage for new changes, which is not met here.
- src/GenerateQrCode.php needs comprehensive tests covering default behavior, transparency settings, and custom options override scenarios
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/GenerateQrCode.php | 4/5 | Sets explicit defaults for QR rendering (GD+PNG+transparency) to match v4 behavior, but lacks tests for new default behavior and custom options override |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant GenerateQrCode
    participant QROptions
    participant QRCode
    
    User->>GenerateQrCode: render(options, file)
    GenerateQrCode->>GenerateQrCode: Check if outputType/outputInterface not set
    alt outputType not set
        GenerateQrCode->>GenerateQrCode: Set outputType = GDIMAGE_PNG
    end
    GenerateQrCode->>GenerateQrCode: Check if imageTransparent not set
    alt imageTransparent not set
        GenerateQrCode->>GenerateQrCode: Set imageTransparent = true
    end
    GenerateQrCode->>QROptions: new QROptions(options)
    QROptions-->>GenerateQrCode: options object
    GenerateQrCode->>GenerateQrCode: toBase64()
    GenerateQrCode->>QRCode: new QRCode(options)
    GenerateQrCode->>QRCode: render(base64Data, file)
    QRCode-->>GenerateQrCode: rendered QR code
    GenerateQrCode-->>User: QR code string
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - All new code changes must include comprehensive automated tests, including unit, integration, and fu... ([source](https://app.greptile.com/review/custom-context?memory=66cc2964-cae6-4fd6-b237-b85e614f3799))

<!-- /greptile_comment -->